### PR TITLE
Scandella patch 1

### DIFF
--- a/src/twigextensions/EagerBeaverTwigExtension.php
+++ b/src/twigextensions/EagerBeaverTwigExtension.php
@@ -42,7 +42,7 @@ class EagerBeaverTwigExtension extends AbstractExtension
     public function getFunctions(): array
     {
         return [
-            new TwigFunction('eagerLoadElements', function (array $elements, array|string $with): void {
+            new TwigFunction('eagerLoadElements', function (ElementInterface|array $elements, array|string $with): void {
                 $this->eagerLoadElements($elements, $with);
             }),
         ];


### PR DESCRIPTION
### Description
Modify the short syntax type declarations.


### Related issues
Can't use the short syntax in Craft 4.